### PR TITLE
Expand ResNet & LeNet Examples for CIFAR

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ Train the classic LeNet5 with 1.58bits linear and convolutional layers
 ```sh
 python examples/mnist_lenet5_example.py
 ```
+3. **LeNet5** `Cifar10`
+```sh
+python examples/cifar10_lenet5_example.py
+```
 
 # License
 MIT

--- a/README.md
+++ b/README.md
@@ -56,6 +56,21 @@ python examples/mnist_lenet5_example.py
 python examples/cifar10_lenet5_example.py
 ```
 
+4. **LeNet5** `Cifar100`
+```sh
+python examples/cifar100_lenet5_example.py
+```
+
+5. **ResNet18** `Cifar100`
+```sh
+python examples/cifar100_resnet18_example.py
+```
+
+6. **ResNet152** `Cifar100`
+```sh
+python examples/cifar100_resnet152_example.py
+```
+
 # License
 MIT
 

--- a/bitnet/models/lenet5.py
+++ b/bitnet/models/lenet5.py
@@ -1,5 +1,6 @@
 import torch.nn as nn
 from torch import Tensor
+
 from bitnet.nn.bitlinear import BitLinear
 from bitnet.nn.bitconv2d import BitConv2d
 

--- a/bitnet/models/resnet.py
+++ b/bitnet/models/resnet.py
@@ -1,0 +1,304 @@
+from typing import Callable
+
+import torch
+import torch.nn as nn
+from torch import Tensor
+
+from bitnet.nn.bitlinear import BitLinear
+from bitnet.nn.bitconv2d import BitConv2d
+
+
+def conv3x3(in_planes: int, conv_layer: nn.Module , out_planes: int, stride: int = 1, groups: int = 1, dilation: int = 1) -> nn.Module:
+    """3x3 convolution with padding"""
+    return conv_layer(
+        in_planes,
+        out_planes,
+        kernel_size=3,
+        stride=stride,
+        padding=dilation,
+        groups=groups,
+        bias=False,
+        dilation=dilation,
+    )
+
+
+def conv1x1(in_planes: int, conv_layer: nn.Module, out_planes: int, stride: int = 1) -> nn.Module:
+    """1x1 convolution"""
+    return conv_layer(in_planes, out_planes, kernel_size=1, stride=stride, bias=False)
+
+
+class BasicBlock(nn.Module):
+    expansion: int = 1
+
+    def __init__(
+        self,
+        inplanes: int,
+        conv_layer: nn.Module,
+        planes: int,
+        stride: int = 1,
+        downsample: nn.Module | None = None,
+        groups: int = 1,
+        base_width: int = 64,
+        dilation: int = 1,
+        norm_layer: Callable[..., nn.Module] = None,
+    ) -> None:
+        super().__init__()
+        if norm_layer is None:
+            norm_layer = nn.BatchNorm2d
+        if groups != 1 or base_width != 64:
+            raise ValueError("BasicBlock only supports groups=1 and base_width=64")
+        if dilation > 1:
+            raise NotImplementedError("Dilation > 1 not supported in BasicBlock")
+        # Both self.conv1 and self.downsample layers downsample the input when stride != 1
+        self.conv1 = conv3x3(inplanes, conv_layer, planes, stride)
+        self.bn1 = norm_layer(planes)
+        self.relu = nn.ReLU(inplace=True)
+        self.conv2 = conv3x3(planes, conv_layer, planes)
+        self.bn2 = norm_layer(planes)
+        self.downsample = downsample
+        self.stride = stride
+
+    def forward(self, x: Tensor) -> Tensor:
+        identity = x
+
+        out = self.conv1(x)
+        out = self.bn1(out)
+        out = self.relu(out)
+
+        out = self.conv2(out)
+        out = self.bn2(out)
+
+        if self.downsample is not None:
+            identity = self.downsample(x)
+
+        out += identity
+        out = self.relu(out)
+
+        return out
+
+
+class Bottleneck(nn.Module):
+    # Bottleneck in torchvision places the stride for downsampling at 3x3 convolution(self.conv2)
+    # while original implementation places the stride at the first 1x1 convolution(self.conv1)
+    # according to "Deep residual learning for image recognition" https://arxiv.org/abs/1512.03385.
+    # This variant is also known as ResNet V1.5 and improves accuracy according to
+    # https://ngc.nvidia.com/catalog/model-scripts/nvidia:resnet_50_v1_5_for_pytorch.
+
+    expansion: int = 4
+
+    def __init__(
+        self,
+        inplanes: int,
+        conv_layer: nn.Module,
+        planes: int,
+        stride: int = 1,
+        downsample: nn.Module | None = None,
+        groups: int = 1,
+        base_width: int = 64,
+        dilation: int = 1,
+        norm_layer: Callable[..., nn.Module] | None = None,
+    ) -> None:
+        super().__init__()
+        if norm_layer is None:
+            norm_layer = nn.BatchNorm2d
+        width = int(planes * (base_width / 64.0)) * groups
+        # Both self.conv2 and self.downsample layers downsample the input when stride != 1
+        self.conv1 = conv1x1(inplanes, conv_layer, width)
+        self.bn1 = norm_layer(width)
+        self.conv2 = conv3x3(width, conv_layer, width, stride, groups, dilation)
+        self.bn2 = norm_layer(width)
+        self.conv3 = conv1x1(width, conv_layer, planes * self.expansion)
+        self.bn3 = norm_layer(planes * self.expansion)
+        self.relu = nn.ReLU(inplace=True)
+        self.downsample = downsample
+        self.stride = stride
+
+    def forward(self, x: Tensor) -> Tensor:
+        identity = x
+
+        out = self.conv1(x)
+        out = self.bn1(out)
+        out = self.relu(out)
+
+        out = self.conv2(out)
+        out = self.bn2(out)
+        out = self.relu(out)
+
+        out = self.conv3(out)
+        out = self.bn3(out)
+
+        if self.downsample is not None:
+            identity = self.downsample(x)
+
+        out += identity
+        out = self.relu(out)
+
+        return out
+
+
+class ResNet(nn.Module):
+    def __init__(
+        self,
+        linear_layer: Callable,
+        conv_layer: Callable,
+        block: BasicBlock | Bottleneck,
+        layers: list[int],
+        num_classes: int = 1000,
+        zero_init_residual: bool = False,
+        groups: int = 1,
+        width_per_group: int = 64,
+        replace_stride_with_dilation: list[bool] | None = None,
+        norm_layer: Callable[..., nn.Module] | None = None,
+    ) -> None:
+        super().__init__()
+        self.linear_layer = linear_layer
+        self.conv_layer = conv_layer
+        if norm_layer is None:
+            norm_layer = nn.BatchNorm2d
+        self._norm_layer = norm_layer
+
+        self.inplanes = 64
+        self.dilation = 1
+        if replace_stride_with_dilation is None:
+            # each element in the tuple indicates if we should replace
+            # the 2x2 stride with a dilated convolution instead
+            replace_stride_with_dilation = [False, False, False]
+        if len(replace_stride_with_dilation) != 3:
+            raise ValueError(
+                "replace_stride_with_dilation should be None "
+                f"or a 3-element tuple, got {replace_stride_with_dilation}"
+            )
+        self.groups = groups
+        self.base_width = width_per_group
+        self.conv1 = conv_layer(3, self.inplanes, kernel_size=7, stride=2, padding=3, bias=False)
+        self.bn1 = norm_layer(self.inplanes)
+        self.relu = nn.ReLU(inplace=True)
+        self.maxpool = nn.MaxPool2d(kernel_size=3, stride=2, padding=1)
+        self.layer1 = self._make_layer(block, 64, layers[0], conv_layer)
+        self.layer2 = self._make_layer(block, 128, layers[1], conv_layer, stride=2, dilate=replace_stride_with_dilation[0])
+        self.layer3 = self._make_layer(block, 256, layers[2], conv_layer, stride=2, dilate=replace_stride_with_dilation[1])
+        self.layer4 = self._make_layer(block, 512, layers[3], conv_layer, stride=2, dilate=replace_stride_with_dilation[2])
+        self.avgpool = nn.AdaptiveAvgPool2d((1, 1))
+        self.fc = linear_layer(512 * block.expansion, num_classes)
+
+        for m in self.modules():
+            if isinstance(m, conv_layer):
+                nn.init.kaiming_normal_(m.weight, mode="fan_out", nonlinearity="relu")
+            elif isinstance(m, (nn.BatchNorm2d, nn.GroupNorm)):
+                nn.init.constant_(m.weight, 1)
+                nn.init.constant_(m.bias, 0)
+
+        # Zero-initialize the last BN in each residual branch,
+        # so that the residual branch starts with zeros, and each residual block behaves like an identity.
+        # This improves the model by 0.2~0.3% according to https://arxiv.org/abs/1706.02677
+        if zero_init_residual:
+            for m in self.modules():
+                if isinstance(m, Bottleneck) and m.bn3.weight is not None:
+                    nn.init.constant_(m.bn3.weight, 0)  # type: ignore[arg-type]
+                elif isinstance(m, BasicBlock) and m.bn2.weight is not None:
+                    nn.init.constant_(m.bn2.weight, 0)  # type: ignore[arg-type]
+
+    def _make_layer(
+        self,
+        block: BasicBlock | Bottleneck,
+        planes: int,
+        blocks: int,
+        conv_layer: nn.Module,
+        stride: int = 1,
+        dilate: bool = False,
+    ) -> nn.Sequential:
+        norm_layer = self._norm_layer
+        downsample = None
+        previous_dilation = self.dilation
+        if dilate:
+            self.dilation *= stride
+            stride = 1
+        if stride != 1 or self.inplanes != planes * block.expansion:
+            downsample = nn.Sequential(
+                conv1x1(self.inplanes, conv_layer, planes * block.expansion, stride),
+                norm_layer(planes * block.expansion),
+            )
+
+        layers = []
+        layers.append(
+            block(
+                self.inplanes, conv_layer, planes, stride, downsample, self.groups, self.base_width, previous_dilation, norm_layer
+            )
+        )
+        self.inplanes = planes * block.expansion
+        for _ in range(1, blocks):
+            layers.append(
+                block(
+                    self.inplanes,
+                    conv_layer,
+                    planes,
+                    groups=self.groups,
+                    base_width=self.base_width,
+                    dilation=self.dilation,
+                    norm_layer=norm_layer,
+                )
+            )
+
+        return nn.Sequential(*layers)
+
+    def _forward_impl(self, x: Tensor) -> Tensor:
+        # See note [TorchScript super()]
+        x = self.conv1(x)
+        x = self.bn1(x)
+        x = self.relu(x)
+        x = self.maxpool(x)
+
+        x = self.layer1(x)
+        x = self.layer2(x)
+        x = self.layer3(x)
+        x = self.layer4(x)
+
+        x = self.avgpool(x)
+        x = torch.flatten(x, 1)
+        x = self.fc(x)
+
+        return x
+
+    @property
+    def __name__(self) -> str:
+        if self.linear_layer == BitLinear or self.conv_layer == BitConv2d:
+            return "BitNet"
+        return "FloatNet"
+
+
+    def forward(self, x: Tensor) -> Tensor:
+        return self._forward_impl(x)
+
+
+def _resnet(
+    linear_layer: Callable,
+    conv_layer: Callable,
+    block: BasicBlock | Bottleneck,
+    layers: list[int],
+    weights: None,#WeightsEnum,
+    progress: bool,
+    **kwargs,
+) -> ResNet:
+    if weights is not None:
+        raise NotImplementedError("Not implemented yet")
+        # _ovewrite_named_param(kwargs, "num_classes", len(weights.meta["categories"]))
+
+    model = ResNet(linear_layer, conv_layer, block, layers, **kwargs)
+
+    if weights is not None:
+        raise NotImplementedError("Not implemented yet")
+        # model.load_state_dict(weights.get_state_dict(progress=progress, check_hash=True))
+
+    return model
+
+
+def resnet18(linear_layer, conv_layer, **kwargs):
+    return _resnet(linear_layer, conv_layer, BasicBlock, [2, 2, 2, 2], weights=None, progress=False, **kwargs)
+
+
+def main():
+    print(resnet18(BitLinear, BitConv2d, num_classes=100))
+
+
+if __name__ == "__main__":
+    main()

--- a/bitnet/models/resnet.py
+++ b/bitnet/models/resnet.py
@@ -336,11 +336,11 @@ def resnet152(linear_layer, conv_layer, pretrained: bool, **kwargs):
 
 
 def main():
-    bit_resnet18 = resnet18(BitLinear, BitConv2d, pretrained=True, num_classes=100)
-    bit_resnet34 = resnet34(BitLinear, BitConv2d, pretrained=True, num_classes=100)
-    bit_resnet50 = resnet50(BitLinear, BitConv2d, pretrained=True, num_classes=100)
-    bit_resnet101 = resnet101(BitLinear, BitConv2d, pretrained=True, num_classes=100)
-    bit_resnet152 = resnet152(BitLinear, BitConv2d, pretrained=True, num_classes=100)
+    _ = resnet18(BitLinear, BitConv2d, pretrained=True, num_classes=100)
+    _ = resnet34(BitLinear, BitConv2d, pretrained=True, num_classes=100)
+    _ = resnet50(BitLinear, BitConv2d, pretrained=True, num_classes=100)
+    _ = resnet101(BitLinear, BitConv2d, pretrained=True, num_classes=100)
+    _ = resnet152(BitLinear, BitConv2d, pretrained=True, num_classes=100)
 
 if __name__ == "__main__":
     main()

--- a/bitnet/nn/bitconv2d.py
+++ b/bitnet/nn/bitconv2d.py
@@ -58,14 +58,3 @@ class BitConv2d(nn.Conv2d):
         output = self.dequantize_activations(output, input_gamma, weight_abs_mean)
 
         return output
-
-
-def main():
-    test_tensor = torch.randn(1, 3, 28, 28)
-    layer = BitConv2d(3, 16, 3)
-    out = layer(test_tensor)
-    print(out)
-
-
-if __name__ == "__main__":
-    main()

--- a/examples/cifar100_lenet5_example.py
+++ b/examples/cifar100_lenet5_example.py
@@ -1,0 +1,94 @@
+import torch
+from torch import nn
+from torchvision import transforms, datasets
+from torch.utils.data import DataLoader
+
+from tqdm import tqdm
+
+from bitnet.nn.bitlinear import BitLinear
+from bitnet.nn.bitconv2d import BitConv2d
+from bitnet.models.lenet5 import LeNet
+from seed import set_seed
+
+
+device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+
+
+def train_model(
+        model: nn.Module,
+        train_loader: DataLoader,
+        optimizer: torch.optim.Optimizer,
+        criterion: nn.CrossEntropyLoss,
+        num_epochs: int) -> None:
+    for epoch in range(num_epochs):
+        pbar = tqdm(total=len(train_loader), desc=f"Training {model.__name__}")
+        running_loss: float = 0.0
+        for i, (images, labels) in enumerate(train_loader):
+            images, labels = images.to(device), labels.to(device)
+            outputs = model(images)
+            loss = criterion(outputs, labels)
+
+            optimizer.zero_grad()
+            loss.backward()
+            optimizer.step()
+
+            running_loss += loss.item()
+            pbar.set_description(
+                f'Model: {model.__name__} - Epoch [{epoch+1}], Loss: {running_loss / (i+1):.4f}'
+            )
+            pbar.update(1)
+        pbar.close()
+
+
+def test_model(model: nn.Module, test_loader: DataLoader):
+    model.eval()
+    correct: int = 0
+    total: int = 0
+    with torch.no_grad():
+        for images, labels in test_loader:
+            images, labels = images.to(device), labels.to(device)
+            outputs = model(images)
+            _, predicted = torch.max(outputs.data, 1)
+            total += labels.size(0)
+            correct += (predicted == labels).sum().item()
+    accuracy = 100 * correct / total
+    print(f'Accuracy of {model.__name__}: {accuracy:.2f}%')
+
+
+def main():
+    num_classes: int        = 100
+    learning_rate: float    = 1e-3
+    num_epochs: int         = 10
+    batch_size: int         = 128
+
+    transform = transforms.Compose([
+        transforms.ToTensor(),
+        transforms.Normalize((0.4914, 0.4822, 0.4465), (0.247, 0.243, 0.261))
+    ])
+
+    bitnet = LeNet(BitLinear, BitConv2d, num_classes, 3, 32).to(device)
+    floatnet = LeNet(nn.Linear, nn.Conv2d, num_classes, 3, 32).to(device)
+
+    bitnet_optimizer = torch.optim.Adam(bitnet.parameters(), lr=learning_rate)
+    floatnet_optimizer = torch.optim.Adam(floatnet.parameters(), lr=learning_rate)
+
+    criterion = nn.CrossEntropyLoss()
+
+    train_dataset = datasets.CIFAR100('./cifar_data', train=True, download=True, transform=transform)
+    test_dataset = datasets.CIFAR100('./cifar_data', train=False, download=True, transform=transform)
+
+    set_seed()
+    train_loader = DataLoader(train_dataset, batch_size=batch_size, shuffle=True)
+    test_loader = DataLoader(test_dataset, batch_size=batch_size, shuffle=False)
+    train_model(bitnet, train_loader, bitnet_optimizer, criterion, num_epochs)
+    test_model(bitnet, test_loader)
+
+    set_seed()
+    train_loader = DataLoader(train_dataset, batch_size=batch_size, shuffle=True)
+    test_loader = DataLoader(test_dataset, batch_size=batch_size, shuffle=False)
+    train_model(floatnet, train_loader, floatnet_optimizer, criterion, num_epochs)
+    test_model(floatnet, test_loader)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/cifar100_resnet152_example.py
+++ b/examples/cifar100_resnet152_example.py
@@ -1,0 +1,94 @@
+import torch
+from torch import nn
+from torchvision import transforms, datasets
+from torch.utils.data import DataLoader
+
+from tqdm import tqdm
+
+from bitnet.nn.bitlinear import BitLinear
+from bitnet.nn.bitconv2d import BitConv2d
+from bitnet.models.resnet import resnet152
+from seed import set_seed
+
+
+device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+
+
+def train_model(
+        model: nn.Module,
+        train_loader: DataLoader,
+        optimizer: torch.optim.Optimizer,
+        criterion: nn.CrossEntropyLoss,
+        num_epochs: int) -> None:
+    for epoch in range(num_epochs):
+        pbar = tqdm(total=len(train_loader), desc=f"Training {model.__name__}")
+        running_loss: float = 0.0
+        for i, (images, labels) in enumerate(train_loader):
+            images, labels = images.to(device), labels.to(device)
+            outputs = model(images)
+            loss = criterion(outputs, labels)
+
+            optimizer.zero_grad()
+            loss.backward()
+            optimizer.step()
+
+            running_loss += loss.item()
+            pbar.set_description(
+                f'Model: {model.__name__} - Epoch [{epoch+1}], Loss: {running_loss / (i+1):.4f}'
+            )
+            pbar.update(1)
+        pbar.close()
+
+
+def test_model(model: nn.Module, test_loader: DataLoader):
+    model.eval()
+    correct: int = 0
+    total: int = 0
+    with torch.no_grad():
+        for images, labels in test_loader:
+            images, labels = images.to(device), labels.to(device)
+            outputs = model(images)
+            _, predicted = torch.max(outputs.data, 1)
+            total += labels.size(0)
+            correct += (predicted == labels).sum().item()
+    accuracy = 100 * correct / total
+    print(f'Accuracy of {model.__name__}: {accuracy:.2f}%')
+
+
+def main():
+    num_classes: int        = 100
+    learning_rate: float    = 1e-3
+    num_epochs: int         = 10
+    batch_size: int         = 128
+
+    transform = transforms.Compose([
+        transforms.ToTensor(),
+        transforms.Normalize((0.4914, 0.4822, 0.4465), (0.247, 0.243, 0.261))
+    ])
+
+    bitnet = resnet152(BitLinear, BitConv2d, pretrained=True, num_classes=num_classes).to(device)
+    floatnet = resnet152(nn.Linear, nn.Conv2d, pretrained=True, num_classes=num_classes).to(device)
+
+    bitnet_optimizer = torch.optim.Adam(bitnet.parameters(), lr=learning_rate)
+    floatnet_optimizer = torch.optim.Adam(floatnet.parameters(), lr=learning_rate)
+
+    criterion = nn.CrossEntropyLoss()
+
+    train_dataset = datasets.CIFAR100('./cifar_data', train=True, download=True, transform=transform)
+    test_dataset = datasets.CIFAR100('./cifar_data', train=False, download=True, transform=transform)
+
+    set_seed()
+    train_loader = DataLoader(train_dataset, batch_size=batch_size, shuffle=True)
+    test_loader = DataLoader(test_dataset, batch_size=batch_size, shuffle=False)
+    train_model(bitnet, train_loader, bitnet_optimizer, criterion, num_epochs)
+    test_model(bitnet, test_loader)
+
+    set_seed()
+    train_loader = DataLoader(train_dataset, batch_size=batch_size, shuffle=True)
+    test_loader = DataLoader(test_dataset, batch_size=batch_size, shuffle=False)
+    train_model(floatnet, train_loader, floatnet_optimizer, criterion, num_epochs)
+    test_model(floatnet, test_loader)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/cifar100_resnet18_example.py
+++ b/examples/cifar100_resnet18_example.py
@@ -66,8 +66,8 @@ def main():
         transforms.Normalize((0.4914, 0.4822, 0.4465), (0.247, 0.243, 0.261))
     ])
 
-    bitnet = resnet18(BitLinear, BitConv2d, num_classes=num_classes).to(device)
-    floatnet = resnet18(nn.Linear, nn.Conv2d, num_classes=num_classes).to(device)
+    bitnet = resnet18(BitLinear, BitConv2d, pretrained=True, num_classes=num_classes).to(device)
+    floatnet = resnet18(nn.Linear, nn.Conv2d, pretrained=True, num_classes=num_classes).to(device)
 
     bitnet_optimizer = torch.optim.Adam(bitnet.parameters(), lr=learning_rate)
     floatnet_optimizer = torch.optim.Adam(floatnet.parameters(), lr=learning_rate)

--- a/examples/cifar100_resnet18_example.py
+++ b/examples/cifar100_resnet18_example.py
@@ -1,0 +1,94 @@
+import torch
+from torch import nn
+from torchvision import transforms, datasets
+from torch.utils.data import DataLoader
+
+from tqdm import tqdm
+
+from bitnet.nn.bitlinear import BitLinear
+from bitnet.nn.bitconv2d import BitConv2d
+from bitnet.models.resnet import resnet18
+from seed import set_seed
+
+
+device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+
+
+def train_model(
+        model: nn.Module,
+        train_loader: DataLoader,
+        optimizer: torch.optim.Optimizer,
+        criterion: nn.CrossEntropyLoss,
+        num_epochs: int) -> None:
+    for epoch in range(num_epochs):
+        pbar = tqdm(total=len(train_loader), desc=f"Training {model.__name__}")
+        running_loss: float = 0.0
+        for i, (images, labels) in enumerate(train_loader):
+            images, labels = images.to(device), labels.to(device)
+            outputs = model(images)
+            loss = criterion(outputs, labels)
+
+            optimizer.zero_grad()
+            loss.backward()
+            optimizer.step()
+
+            running_loss += loss.item()
+            pbar.set_description(
+                f'Model: {model.__name__} - Epoch [{epoch+1}], Loss: {running_loss / (i+1):.4f}'
+            )
+            pbar.update(1)
+        pbar.close()
+
+
+def test_model(model: nn.Module, test_loader: DataLoader):
+    model.eval()
+    correct: int = 0
+    total: int = 0
+    with torch.no_grad():
+        for images, labels in test_loader:
+            images, labels = images.to(device), labels.to(device)
+            outputs = model(images)
+            _, predicted = torch.max(outputs.data, 1)
+            total += labels.size(0)
+            correct += (predicted == labels).sum().item()
+    accuracy = 100 * correct / total
+    print(f'Accuracy of {model.__name__}: {accuracy:.2f}%')
+
+
+def main():
+    num_classes: int        = 100
+    learning_rate: float    = 1e-3
+    num_epochs: int         = 10
+    batch_size: int         = 128
+
+    transform = transforms.Compose([
+        transforms.ToTensor(),
+        transforms.Normalize((0.4914, 0.4822, 0.4465), (0.247, 0.243, 0.261))
+    ])
+
+    bitnet = resnet18(BitLinear, BitConv2d, num_classes=num_classes).to(device)
+    floatnet = resnet18(nn.Linear, nn.Conv2d, num_classes=num_classes).to(device)
+
+    bitnet_optimizer = torch.optim.Adam(bitnet.parameters(), lr=learning_rate)
+    floatnet_optimizer = torch.optim.Adam(floatnet.parameters(), lr=learning_rate)
+
+    criterion = nn.CrossEntropyLoss()
+
+    train_dataset = datasets.CIFAR100('./cifar_data', train=True, download=True, transform=transform)
+    test_dataset = datasets.CIFAR100('./cifar_data', train=False, download=True, transform=transform)
+
+    set_seed()
+    train_loader = DataLoader(train_dataset, batch_size=batch_size, shuffle=True)
+    test_loader = DataLoader(test_dataset, batch_size=batch_size, shuffle=False)
+    train_model(bitnet, train_loader, bitnet_optimizer, criterion, num_epochs)
+    test_model(bitnet, test_loader)
+
+    set_seed()
+    train_loader = DataLoader(train_dataset, batch_size=batch_size, shuffle=True)
+    test_loader = DataLoader(test_dataset, batch_size=batch_size, shuffle=False)
+    train_model(floatnet, train_loader, floatnet_optimizer, criterion, num_epochs)
+    test_model(floatnet, test_loader)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What does this PR do?

Introduces additional example scripts and incorporates `ResNet` models to the `BitNet` framework.

* Added CIFAR-10 and CIFAR-100 training examples for LeNet-5.
* Integratesd `ResNet` variants (18, 34, 50, 101, 152) with support for `BitLinear` and `BitConv2d` layers.
* Updated `README` to include instructions for new `CIFAR-10` `LeNet-5` example and `CIFAR-100` `LeNet-5` and `ResNet` examples.